### PR TITLE
Add ptosc toolkit, integration tests, and CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: test
+          MYSQL_DATABASE: ptosc
+          MYSQL_USER: testuser
+          MYSQL_PASSWORD: password
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -ptest"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=20
+    env:
+      DB_HOST: 127.0.0.1
+      DB_PORT: 3306
+      DB_USER: root
+      DB_PASSWORD: test
+      DB_NAME: ptosc
+      ENABLE_PTOSC_METRICS: 'true'
+      LOG_LEVEL: info
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run db:wait
+      - run: npm run migrate
+      - run: npm run seed
+      - name: Run integration tests
+        run: |
+          set -o pipefail
+          npm run ptosc:validate | tee ptosc-test.log
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: ptosc-logs
+          path: ptosc-test.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,10 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
+      - name: Install Percona Toolkit
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y percona-toolkit
       - run: npm ci
       - run: npm run db:wait
       - run: npm run migrate

--- a/README.md
+++ b/README.md
@@ -93,8 +93,10 @@ MySQL 8.0 service and runs the full suite on every push/PR.
 ## Troubleshooting
 
 - **MySQL connection errors** – ensure the credentials in `knexfile.js` match your environment or export `DB_*` variables.
-- **pt-osc binary missing** – install Percona Toolkit locally or set `PTOSC_PATH` when calling the CLI. The provided
-  `scripts/mock-ptosc.js` is useful for offline development or CI environments without the binary.
+- **pt-osc binary missing** – install Percona Toolkit locally or set `PTOSC_PATH` when calling the CLI. The helper in
+  `src/ptosc-options.js` automatically falls back to `scripts/mock-ptosc.js` whenever `pt-online-schema-change` is not
+  discoverable on your `PATH` (unless you set `PTOSC_ALLOW_MOCK=false`). This keeps CI/local development productive while
+  still allowing you to require the real binary when desired.
 - **Metrics not visible** – confirm `ENABLE_PTOSC_METRICS` is not set to `false` and that port `9464` is reachable. When using Docker
   on Linux you may need to update `ops/prometheus.yml` to point at the host IP rather than `host.docker.internal`.
 - **Dry-run schema leftovers** – set `PTOSC_KEEP_DRYRUN_DB=false` (default) so the toolkit drops ephemeral databases after execution.

--- a/README.md
+++ b/README.md
@@ -1,23 +1,111 @@
 # kpp-test-app
 
-Test app for [knex-ptosc-plugin](https://github.com/gwinans/knex-ptosc-plugin/)
+A companion project for exercising the [`knex-ptosc-plugin`](https://github.com/gwinans/knex-ptosc-plugin/) against realistic
+schemas and data volumes. The repository now bundles:
 
-This project demonstrates Knex migrations using a MySQL database.
+- Rich sample schemas with foreign keys, composite indexes, and warehouse-level inventory snapshots.
+- Deterministic seed fixtures that populate hundreds of orders and time-series rows for before/after comparisons.
+- Structured logging plus optional Prometheus metrics so you can observe `pt-online-schema-change` runs.
+- A small CLI (`bin/ptosc-toolkit.js`) that wraps common workflows like migrations, dry runs, and validation.
+- Node integration tests that execute real migrations through the plugin (including enum changes) and assert both schema state and
+  captured pt-osc logs.
+- CI automation that spins up MySQL, runs migrations with the plugin, and exposes logs for debugging failures.
 
-## Migrations
+## Prerequisites
 
-Ensure you have a MySQL server running and a database (default `test_db`) available. Connection settings can be customized via environment variables: `DB_HOST`, `DB_USER`, `DB_PASSWORD`, and `DB_NAME`. By default the app connects with user `testuser` and password `password`.
+- Node.js 18+
+- MySQL 8.0+ (local install or Docker). The defaults expect `root` / `test` with database `ptosc`.
+- [`pt-online-schema-change`](https://www.percona.com/doc/percona-toolkit/) if you plan to run against a real Percona Toolkit
+  install. The integration tests also provide a deterministic `scripts/mock-ptosc.js` shim for environments without the binary.
+- Optional: Docker/Docker Compose for the provided environment recipe and Prometheus monitoring stack.
 
-Run the latest migrations:
+Connection details can be overridden with the usual environment variables: `DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD`, and
+`DB_NAME`.
+
+## Quick start with Docker Compose
 
 ```bash
+# Launch MySQL and Prometheus locally
+docker compose up -d
+
+# Wait for MySQL to become healthy and run migrations + seeds
+npm run db:wait
 npm run migrate
+npm run seed
 ```
 
-Rollback the last batch:
+With the containers running you can export `ENABLE_PTOSC_METRICS=true` (default) to expose metrics at `http://localhost:9464`.
+Prometheus is configured via `ops/prometheus.yml` to scrape that endpoint automatically when using Docker Desktop.
 
-```bash
-npm run rollback
-```
+## CLI workflow recipes
 
-The migration files live in the `migrations/` directory and are configured via `knexfile.js`.
+All of the project automation routes through `npm` scripts backed by `bin/ptosc-toolkit.js`:
+
+| Command | Description |
+| --- | --- |
+| `npm run migrate` | Apply the latest migrations using the pt-osc aware helpers (metrics enabled by default). |
+| `npm run rollback` | Roll back the most recent migration batch. |
+| `npm run seed` | Load deterministic sample data defined in `fixtures/`. |
+| `npm run ptosc:plan` | List pending migrations without executing them. |
+| `npm run ptosc:dry-run` | Execute migrations against an ephemeral database clone (drops the clone after completion unless `PTOSC_KEEP_DRYRUN_DB=true`). |
+| `npm run ptosc:validate` | Run the integration test suite (`node --test`) to verify migrations, plugin behaviour, and observability wiring. |
+| `npm run db:wait` | Block until the configured MySQL instance is available (useful in CI or when booting Docker). |
+
+Set `RUN_SEEDS_AFTER_MIGRATE=true` to automatically seed after migrations, or `RUN_SEEDS_IN_DRY_RUN=true` to seed dry-run clones.
+
+## Seeding & fixtures
+
+Deterministic fixtures live under `fixtures/` (`warehouses.json`, `gadgets.json`, `customers.json`). The seed script builds a
+realistic workload:
+
+- Hundreds of orders distributed across multiple customers.
+- Thousands of `order_items` rows referencing composite indexes.
+- Thirty days of inventory snapshots per gadget/warehouse pair.
+
+This data volume helps surface pt-osc edge cases such as chunk sizing and ETA reporting.
+
+## Observability
+
+The helper in `src/ptosc-options.js` provides structured logging via [`pino`](https://github.com/pinojs/pino) and optional metrics via
+[`prom-client`](https://github.com/siimon/prom-client):
+
+- Progress updates emit JSON logs (`event=ptosc_progress`) and are mirrored to a Prometheus gauge (`ptosc_progress_percent`).
+- Final statistics from pt-osc runs are captured and logged for later inspection.
+- `startMetricsServer()` exposes metrics on port `9464` by default; set `METRICS_PORT` to override or `ENABLE_PTOSC_METRICS=false`
+  to disable metric emission entirely.
+
+When running with Docker Compose, Prometheus scrapes the metrics endpoint automatically (see `ops/prometheus.yml`). For local
+experiments you can also hit `curl localhost:9464/metrics` to inspect the latest values.
+
+## Integration tests
+
+`npm run ptosc:validate` runs the integration suite in `tests/`:
+
+- Spins up a dedicated database schema per run.
+- Executes every migration, seeds repeatable fixtures, and verifies relational integrity (foreign keys, composite indexes, enum state).
+- Forces `alterTableWithPtosc` through a deterministic mock pt-osc binary to assert on captured progress logs and statistics while
+  still applying the actual `ALTER TABLE` back to MySQL.
+- Confirms that the Prometheus gauge records 100% completion for each run.
+
+If MySQL is unavailable the tests are skipped with a helpful message. The GitHub Action (see `.github/workflows/ci.yml`) provisions a
+MySQL 8.0 service and runs the full suite on every push/PR.
+
+## Troubleshooting
+
+- **MySQL connection errors** – ensure the credentials in `knexfile.js` match your environment or export `DB_*` variables.
+- **pt-osc binary missing** – install Percona Toolkit locally or set `PTOSC_PATH` when calling the CLI. The provided
+  `scripts/mock-ptosc.js` is useful for offline development or CI environments without the binary.
+- **Metrics not visible** – confirm `ENABLE_PTOSC_METRICS` is not set to `false` and that port `9464` is reachable. When using Docker
+  on Linux you may need to update `ops/prometheus.yml` to point at the host IP rather than `host.docker.internal`.
+- **Dry-run schema leftovers** – set `PTOSC_KEEP_DRYRUN_DB=false` (default) so the toolkit drops ephemeral databases after execution.
+
+## Validating migrations before promotion
+
+1. Run `npm run ptosc:plan` to review pending migrations.
+2. Execute `npm run ptosc:dry-run` to rehearse against an isolated database clone.
+3. Inspect the generated logs (JSON structured with progress) and, if metrics are enabled, open the Prometheus UI at
+   `http://localhost:9090` and query `ptosc_progress_percent`.
+4. Once satisfied, run `npm run migrate` followed by `npm run seed` and `npm run ptosc:validate` to ensure the integration tests pass.
+
+These steps mimic the CI workflow and help catch enum changes, constraint adjustments, and long-running pt-osc migrations before they
+reach production.

--- a/bin/ptosc-toolkit.js
+++ b/bin/ptosc-toolkit.js
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+'use strict';
+
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+const process = require('node:process');
+const mysql = require('mysql2/promise');
+const knexFactory = require('knex');
+const knexfile = require('../knexfile.js');
+const { startMetricsServer, getBaseLogger } = require('../src/ptosc-options.js');
+
+const commands = new Set(['migrate', 'rollback', 'plan', 'seed', 'dry-run', 'validate']);
+
+async function run() {
+  const command = process.argv[2];
+  if (!commands.has(command)) {
+    printHelp();
+    process.exit(command ? 1 : 0);
+  }
+
+  if (process.env.ENABLE_PTOSC_METRICS !== 'false') {
+    startMetricsServer();
+  }
+
+  switch (command) {
+    case 'migrate':
+      await runMigrations();
+      break;
+    case 'rollback':
+      await runRollback();
+      break;
+    case 'plan':
+      await runPlan();
+      break;
+    case 'seed':
+      await runSeed();
+      break;
+    case 'dry-run':
+      await runDryRun();
+      break;
+    case 'validate':
+      await runValidate();
+      break;
+  }
+}
+
+function getConnectionConfig() {
+  const cfg = knexfile.development;
+  return { ...cfg, connection: { ...cfg.connection } };
+}
+
+async function createKnex(connectionOverride) {
+  const cfg = getConnectionConfig();
+  if (connectionOverride) {
+    cfg.connection = { ...cfg.connection, ...connectionOverride };
+  }
+  return knexFactory(cfg);
+}
+
+async function runMigrations(connectionOverride) {
+  const knex = await createKnex(connectionOverride);
+  try {
+    await knex.migrate.latest();
+    if (process.env.RUN_SEEDS_AFTER_MIGRATE === 'true') {
+      await knex.seed.run();
+    }
+    getBaseLogger().info({ command: 'migrate' }, 'Migrations complete');
+  } finally {
+    await knex.destroy();
+  }
+}
+
+async function runRollback() {
+  const knex = await createKnex();
+  try {
+    await knex.migrate.rollback(undefined, true);
+    getBaseLogger().info({ command: 'rollback' }, 'Rollback complete');
+  } finally {
+    await knex.destroy();
+  }
+}
+
+async function runPlan() {
+  const knex = await createKnex();
+  try {
+    let pending;
+    try {
+      [, pending] = await knex.migrate.list();
+    } catch (err) {
+      console.warn('Unable to inspect migrations:', err.message);
+      return;
+    }
+    if (!pending.length) {
+      console.log('No pending migrations.');
+    } else {
+      console.log('Pending migrations:');
+      pending.forEach((file) => console.log(` • ${path.basename(file.file)}`));
+    }
+  } finally {
+    await knex.destroy();
+  }
+}
+
+async function runSeed(connectionOverride) {
+  const knex = await createKnex(connectionOverride);
+  try {
+    await knex.seed.run();
+    getBaseLogger().info({ command: 'seed' }, 'Seed data applied');
+  } finally {
+    await knex.destroy();
+  }
+}
+
+async function runDryRun() {
+  const cfg = getConnectionConfig();
+  const dbName = `${cfg.connection.database}_dryrun_${Date.now()}`;
+  const adminConnection = { ...cfg.connection };
+  delete adminConnection.database;
+
+  const admin = await mysql.createConnection(adminConnection);
+  const logger = getBaseLogger();
+  const keepDatabase = process.env.PTOSC_KEEP_DRYRUN_DB === 'true';
+  try {
+    await admin.query(`CREATE DATABASE \`${dbName}\``);
+    logger.info({ command: 'dry-run', database: dbName }, 'Created dry-run database');
+    await runMigrations({ database: dbName });
+    if (process.env.RUN_SEEDS_IN_DRY_RUN === 'true') {
+      await runSeed({ database: dbName });
+    }
+  } finally {
+    await admin.end();
+    if (keepDatabase) {
+      logger.warn({ command: 'dry-run', database: dbName }, 'Keeping dry-run database for inspection');
+      return;
+    }
+    const dropConn = await mysql.createConnection(adminConnection);
+    try {
+      await dropConn.query(`DROP DATABASE IF EXISTS \`${dbName}\``);
+      logger.info({ command: 'dry-run', database: dbName }, 'Dry-run database dropped');
+    } finally {
+      await dropConn.end();
+    }
+  }
+}
+
+async function runValidate() {
+  const result = spawnSync(process.execPath, ['--test', 'tests'], {
+    stdio: 'inherit',
+    env: process.env
+  });
+  if (result.status !== 0) {
+    process.exit(result.status || 1);
+  }
+}
+
+function printHelp() {
+  console.log('Usage: npm run <script>');
+  console.log('Available scripts:');
+  console.log('  npm run migrate         Run pending migrations with pt-osc integration');
+  console.log('  npm run rollback        Roll back the last migration batch');
+  console.log('  npm run seed            Load deterministic sample data fixtures');
+  console.log('  npm run ptosc:plan      Show pending migrations without executing them');
+  console.log('  npm run ptosc:dry-run   Execute migrations against a temporary database');
+  console.log('  npm run ptosc:validate  Run integration tests against pt-osc flows');
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.9'
+services:
+  mysql:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: test
+      MYSQL_DATABASE: ptosc
+      MYSQL_USER: testuser
+      MYSQL_PASSWORD: password
+    ports:
+      - '3306:3306'
+    healthcheck:
+      test: ['CMD', 'mysqladmin', 'ping', '-h', '127.0.0.1', '-ptest']
+      interval: 5s
+      timeout: 5s
+      retries: 20
+    volumes:
+      - mysql-data:/var/lib/mysql
+  prometheus:
+    image: prom/prometheus:latest
+    depends_on:
+      - mysql
+    ports:
+      - '9090:9090'
+    volumes:
+      - ./ops/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+volumes:
+  mysql-data:

--- a/fixtures/customers.json
+++ b/fixtures/customers.json
@@ -1,0 +1,7 @@
+[
+  { "external_id": "CUST-1000", "email": "amy.anderson@example.com", "full_name": "Amy Anderson", "status": "active" },
+  { "external_id": "CUST-1001", "email": "brian.banks@example.com", "full_name": "Brian Banks", "status": "active" },
+  { "external_id": "CUST-1002", "email": "carla.cortez@example.com", "full_name": "Carla Cortez", "status": "prospect" },
+  { "external_id": "CUST-1003", "email": "darius.dunn@example.com", "full_name": "Darius Dunn", "status": "active" },
+  { "external_id": "CUST-1004", "email": "erin.evans@example.com", "full_name": "Erin Evans", "status": "churned" }
+]

--- a/fixtures/gadgets.json
+++ b/fixtures/gadgets.json
@@ -1,0 +1,7 @@
+[
+  { "title": "Flux Capacitor", "status": "active", "qty": 25, "price": 19999.99, "warehouse": "SEA-01" },
+  { "title": "Hoverboard", "status": "active", "qty": 80, "price": 3499.00, "warehouse": "IAD-02" },
+  { "title": "Sonic Screwdriver", "status": "pending", "qty": 150, "price": 129.99, "warehouse": "FRA-01" },
+  { "title": "Portal Gun", "status": "active", "qty": 45, "price": 7999.50, "warehouse": "SEA-01" },
+  { "title": "Neuralyzer", "status": "pending", "qty": 65, "price": 4599.00, "warehouse": "IAD-02" }
+]

--- a/fixtures/warehouses.json
+++ b/fixtures/warehouses.json
@@ -1,0 +1,5 @@
+[
+  { "code": "SEA-01", "region": "us-west" },
+  { "code": "IAD-02", "region": "us-east" },
+  { "code": "FRA-01", "region": "eu-central" }
+]

--- a/knexfile.js
+++ b/knexfile.js
@@ -9,6 +9,9 @@ module.exports = {
     },
     migrations: {
       directory: './migrations'
+    },
+    seeds: {
+      directory: './seeds'
     }
   }
 };

--- a/migrations/20250101000000_create_widgets_table.js
+++ b/migrations/20250101000000_create_widgets_table.js
@@ -8,6 +8,9 @@ exports.up = function (knex) {
     table.string('name').notNullable();
     table.integer('qty').notNullable();
     table.enu('status', ['active', 'inactive']).notNullable().defaultTo('active');
+    table.decimal('price', 10, 2).notNullable().defaultTo(0);
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+    table.timestamp('updated_at').defaultTo(knex.fn.now());
   });
 };
 

--- a/migrations/20250101000001_rename_name_to_title.js
+++ b/migrations/20250101000001_rename_name_to_title.js
@@ -2,14 +2,27 @@
  * Rename the name column to title in widgets.
  */
 
+const { alterTableWithPtosc } = require('knex-ptosc-plugin');
+const { createPtoscOptions } = require('../src/ptosc-options');
+
 exports.up = function (knex) {
-  return knex.schema.alterTable('widgets', function(table) {
-    table.renameColumn('name', 'title');
-  });
+  return alterTableWithPtosc(
+    knex,
+    'widgets',
+    (table) => {
+      table.renameColumn('name', 'title');
+    },
+    createPtoscOptions('rename_widgets_name_to_title')
+  );
 };
 
 exports.down = function (knex) {
-  return knex.schema.alterTable('widgets', function(table) {
-    table.renameColumn('title', 'name');
-  });
+  return alterTableWithPtosc(
+    knex,
+    'widgets',
+    (table) => {
+      table.renameColumn('title', 'name');
+    },
+    createPtoscOptions('rename_widgets_title_to_name')
+  );
 };

--- a/migrations/20250101000001_rename_name_to_title.js
+++ b/migrations/20250101000001_rename_name_to_title.js
@@ -2,27 +2,21 @@
  * Rename the name column to title in widgets.
  */
 
-const { alterTableWithPtosc } = require('knex-ptosc-plugin');
+const { alterTableWithPtoscRaw } = require('knex-ptosc-plugin');
 const { createPtoscOptions } = require('../src/ptosc-options');
 
 exports.up = function (knex) {
-  return alterTableWithPtosc(
+  return alterTableWithPtoscRaw(
     knex,
-    'widgets',
-    (table) => {
-      table.renameColumn('name', 'title');
-    },
+    'ALTER TABLE widgets CHANGE COLUMN `name` `title` VARCHAR(255) NOT NULL',
     createPtoscOptions('rename_widgets_name_to_title')
   );
 };
 
 exports.down = function (knex) {
-  return alterTableWithPtosc(
+  return alterTableWithPtoscRaw(
     knex,
-    'widgets',
-    (table) => {
-      table.renameColumn('title', 'name');
-    },
+    'ALTER TABLE widgets CHANGE COLUMN `title` `name` VARCHAR(255) NOT NULL',
     createPtoscOptions('rename_widgets_title_to_name')
   );
 };

--- a/migrations/20250101000002_change_qty_to_bigint.js
+++ b/migrations/20250101000002_change_qty_to_bigint.js
@@ -2,15 +2,26 @@
  * Change qty column from integer to bigInteger.
  */
 const { alterTableWithPtosc } = require('knex-ptosc-plugin');
+const { createPtoscOptions } = require('../src/ptosc-options');
 
 exports.up = function (knex) {
-  return alterTableWithPtosc(knex, 'widgets', (table) => {
-    table.bigInteger('qty').alter();
-  });
+  return alterTableWithPtosc(
+    knex,
+    'widgets',
+    (table) => {
+      table.bigInteger('qty').alter();
+    },
+    createPtoscOptions('widgets_qty_bigint')
+  );
 };
 
 exports.down = function (knex) {
-  return alterTableWithPtosc(knex, 'widgets', (table) => {
-    table.integer('qty').alter();
-  });
+  return alterTableWithPtosc(
+    knex,
+    'widgets',
+    (table) => {
+      table.integer('qty').alter();
+    },
+    createPtoscOptions('widgets_qty_int')
+  );
 };

--- a/migrations/20250101000003_add_pending_to_status_enum.js
+++ b/migrations/20250101000003_add_pending_to_status_enum.js
@@ -2,23 +2,34 @@
  * Add 'pending' to the status enum on widgets.
  */
 const { alterTableWithPtosc } = require('knex-ptosc-plugin');
+const { createPtoscOptions } = require('../src/ptosc-options');
 
 exports.up = function (knex) {
-  return alterTableWithPtosc(knex, 'widgets', (table) => {
-    table
-      .enu('status', ['active', 'inactive', 'pending'])
-      .notNullable()
-      .defaultTo('active')
-      .alter();
-  });
+  return alterTableWithPtosc(
+    knex,
+    'widgets',
+    (table) => {
+      table
+        .enu('status', ['active', 'inactive', 'pending'])
+        .notNullable()
+        .defaultTo('active')
+        .alter();
+    },
+    createPtoscOptions('widgets_status_add_pending')
+  );
 };
 
 exports.down = function (knex) {
-  return alterTableWithPtosc(knex, 'widgets', (table) => {
-    table
-      .enu('status', ['active', 'inactive'])
-      .notNullable()
-      .defaultTo('active')
-      .alter();
-  });
+  return alterTableWithPtosc(
+    knex,
+    'widgets',
+    (table) => {
+      table
+        .enu('status', ['active', 'inactive'])
+        .notNullable()
+        .defaultTo('active')
+        .alter();
+    },
+    createPtoscOptions('widgets_status_remove_pending')
+  );
 };

--- a/migrations/20250101000004_remove_inactive_from_status_enum.js
+++ b/migrations/20250101000004_remove_inactive_from_status_enum.js
@@ -2,23 +2,34 @@
  * Remove 'inactive' from the status enum on widgets.
  */
 const { alterTableWithPtosc } = require('knex-ptosc-plugin');
+const { createPtoscOptions } = require('../src/ptosc-options');
 
 exports.up = function (knex) {
-  return alterTableWithPtosc(knex, 'widgets', (table) => {
-    table
-      .enu('status', ['active', 'pending'])
-      .notNullable()
-      .defaultTo('active')
-      .alter();
-  });
+  return alterTableWithPtosc(
+    knex,
+    'widgets',
+    (table) => {
+      table
+        .enu('status', ['active', 'pending'])
+        .notNullable()
+        .defaultTo('active')
+        .alter();
+    },
+    createPtoscOptions('widgets_status_remove_inactive')
+  );
 };
 
 exports.down = function (knex) {
-  return alterTableWithPtosc(knex, 'widgets', (table) => {
-    table
-      .enu('status', ['active', 'inactive', 'pending'])
-      .notNullable()
-      .defaultTo('active')
-      .alter();
-  });
+  return alterTableWithPtosc(
+    knex,
+    'widgets',
+    (table) => {
+      table
+        .enu('status', ['active', 'inactive', 'pending'])
+        .notNullable()
+        .defaultTo('active')
+        .alter();
+    },
+    createPtoscOptions('widgets_status_restore_inactive')
+  );
 };

--- a/migrations/20250101000006_add_gadgets_indexes.js
+++ b/migrations/20250101000006_add_gadgets_indexes.js
@@ -2,17 +2,28 @@
  * Add single and compound indexes to gadgets.
  */
 const { alterTableWithPtosc } = require('knex-ptosc-plugin');
+const { createPtoscOptions } = require('../src/ptosc-options');
 
 exports.up = function (knex) {
-  return alterTableWithPtosc(knex, 'gadgets', (table) => {
-    table.index('title', 'gadgets_title_idx');
-    table.index(['status', 'qty'], 'gadgets_status_qty_idx');
-  });
+  return alterTableWithPtosc(
+    knex,
+    'gadgets',
+    (table) => {
+      table.index('title', 'gadgets_title_idx');
+      table.index(['status', 'qty'], 'gadgets_status_qty_idx');
+    },
+    createPtoscOptions('gadgets_add_indexes')
+  );
 };
 
 exports.down = function (knex) {
-  return alterTableWithPtosc(knex, 'gadgets', (table) => {
-    table.dropIndex('title', 'gadgets_title_idx');
-    table.dropIndex(['status', 'qty'], 'gadgets_status_qty_idx');
-  });
+  return alterTableWithPtosc(
+    knex,
+    'gadgets',
+    (table) => {
+      table.dropIndex('title', 'gadgets_title_idx');
+      table.dropIndex(['status', 'qty'], 'gadgets_status_qty_idx');
+    },
+    createPtoscOptions('gadgets_drop_indexes')
+  );
 };

--- a/migrations/20250101000007_drop_gadgets_indexes.js
+++ b/migrations/20250101000007_drop_gadgets_indexes.js
@@ -2,17 +2,28 @@
  * Remove the previously added indexes from gadgets.
  */
 const { alterTableWithPtosc } = require('knex-ptosc-plugin');
+const { createPtoscOptions } = require('../src/ptosc-options');
 
 exports.up = function (knex) {
-  return alterTableWithPtosc(knex, 'gadgets', (table) => {
-    table.dropIndex('title', 'gadgets_title_idx');
-    table.dropIndex(['status', 'qty'], 'gadgets_status_qty_idx');
-  });
+  return alterTableWithPtosc(
+    knex,
+    'gadgets',
+    (table) => {
+      table.dropIndex('title', 'gadgets_title_idx');
+      table.dropIndex(['status', 'qty'], 'gadgets_status_qty_idx');
+    },
+    createPtoscOptions('gadgets_indexes_cleanup')
+  );
 };
 
 exports.down = function (knex) {
-  return alterTableWithPtosc(knex, 'gadgets', (table) => {
-    table.index('title', 'gadgets_title_idx');
-    table.index(['status', 'qty'], 'gadgets_status_qty_idx');
-  });
+  return alterTableWithPtosc(
+    knex,
+    'gadgets',
+    (table) => {
+      table.index('title', 'gadgets_title_idx');
+      table.index(['status', 'qty'], 'gadgets_status_qty_idx');
+    },
+    createPtoscOptions('gadgets_indexes_restore')
+  );
 };

--- a/migrations/20250101000008_create_sales_tables.js
+++ b/migrations/20250101000008_create_sales_tables.js
@@ -1,0 +1,87 @@
+/**
+ * Create relational tables that mimic production datasets with foreign keys
+ * and composite indexes.
+ */
+
+exports.up = async function (knex) {
+  await knex.schema.createTable('customers', (table) => {
+    table.increments('id').primary().unsigned();
+    table.string('external_id').notNullable().unique();
+    table.string('email').notNullable().unique();
+    table.string('full_name').notNullable();
+    table.enu('status', ['prospect', 'active', 'churned']).notNullable().defaultTo('prospect');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+    table.timestamp('updated_at').defaultTo(knex.fn.now());
+  });
+
+  await knex.schema.createTable('warehouses', (table) => {
+    table.increments('id').primary().unsigned();
+    table.string('code').notNullable().unique();
+    table.string('region').notNullable();
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+  });
+
+  await knex.schema.createTable('orders', (table) => {
+    table.increments('id').primary().unsigned();
+    table.string('order_number').notNullable().unique();
+    table.integer('customer_id').unsigned().notNullable();
+    table.bigInteger('total_cents').notNullable();
+    table.enu('status', ['pending', 'processing', 'fulfilled', 'cancelled']).notNullable().defaultTo('pending');
+    table.timestamp('placed_at').notNullable().defaultTo(knex.fn.now());
+    table.timestamp('fulfilled_at');
+    table
+      .foreign('customer_id')
+      .references('id')
+      .inTable('customers')
+      .onDelete('CASCADE');
+    table.index(['customer_id', 'placed_at'], 'orders_customer_placed_idx');
+    table.index(['status', 'placed_at'], 'orders_status_placed_idx');
+  });
+
+  await knex.schema.createTable('order_items', (table) => {
+    table.increments('id').primary().unsigned();
+    table.integer('order_id').unsigned().notNullable();
+    table.integer('gadget_id').unsigned().notNullable();
+    table.integer('quantity').unsigned().notNullable();
+    table.bigInteger('price_cents').notNullable();
+    table
+      .foreign('order_id')
+      .references('id')
+      .inTable('orders')
+      .onDelete('CASCADE');
+    table
+      .foreign('gadget_id')
+      .references('id')
+      .inTable('gadgets')
+      .onDelete('CASCADE');
+    table.index(['order_id', 'gadget_id'], 'order_items_order_gadget_idx');
+  });
+
+  await knex.schema.createTable('inventory_snapshots', (table) => {
+    table.increments('id').primary().unsigned();
+    table.integer('gadget_id').unsigned().notNullable();
+    table.integer('warehouse_id').unsigned().notNullable();
+    table.date('snapshot_date').notNullable();
+    table.bigInteger('quantity').notNullable();
+    table
+      .foreign('gadget_id')
+      .references('id')
+      .inTable('gadgets')
+      .onDelete('CASCADE');
+    table
+      .foreign('warehouse_id')
+      .references('id')
+      .inTable('warehouses')
+      .onDelete('CASCADE');
+    table.unique(['gadget_id', 'warehouse_id', 'snapshot_date'], 'inventory_snapshots_unique');
+    table.index(['warehouse_id', 'snapshot_date'], 'inventory_snapshots_wh_snapshot_idx');
+  });
+};
+
+exports.down = async function (knex) {
+  await knex.schema.dropTableIfExists('inventory_snapshots');
+  await knex.schema.dropTableIfExists('order_items');
+  await knex.schema.dropTableIfExists('orders');
+  await knex.schema.dropTableIfExists('warehouses');
+  await knex.schema.dropTableIfExists('customers');
+};

--- a/migrations/20250101000009_add_gadgets_warehouse_fk.js
+++ b/migrations/20250101000009_add_gadgets_warehouse_fk.js
@@ -1,0 +1,48 @@
+/**
+ * Link gadgets to warehouses to exercise foreign key changes via pt-osc.
+ */
+const { alterTableWithPtosc, alterTableWithPtoscRaw } = require('knex-ptosc-plugin');
+const { createPtoscOptions } = require('../src/ptosc-options');
+
+exports.up = async function (knex) {
+  await alterTableWithPtosc(
+    knex,
+    'gadgets',
+    (table) => {
+      table.integer('warehouse_id').unsigned().nullable().index('gadgets_warehouse_idx');
+    },
+    createPtoscOptions('gadgets_add_warehouse_id')
+  );
+
+  await alterTableWithPtoscRaw(
+    knex,
+    'ALTER TABLE gadgets ADD CONSTRAINT gadgets_warehouse_fk FOREIGN KEY (warehouse_id) REFERENCES warehouses(id) ON DELETE SET NULL',
+    createPtoscOptions('gadgets_add_warehouse_fk')
+  );
+};
+
+exports.down = async function (knex) {
+  await alterTableWithPtoscRaw(
+    knex,
+    'ALTER TABLE gadgets DROP FOREIGN KEY gadgets_warehouse_fk',
+    createPtoscOptions('gadgets_drop_warehouse_fk')
+  );
+
+  await alterTableWithPtosc(
+    knex,
+    'gadgets',
+    (table) => {
+      table.dropIndex('warehouse_id', 'gadgets_warehouse_idx');
+    },
+    createPtoscOptions('gadgets_drop_warehouse_idx')
+  );
+
+  await alterTableWithPtosc(
+    knex,
+    'gadgets',
+    (table) => {
+      table.dropColumn('warehouse_id');
+    },
+    createPtoscOptions('gadgets_remove_warehouse_id')
+  );
+};

--- a/ops/prometheus.yml
+++ b/ops/prometheus.yml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 5s
+scrape_configs:
+  - job_name: 'ptosc-tests'
+    static_configs:
+      - targets:
+          - 'host.docker.internal:9464'
+        labels:
+          service: 'kpp-test-app'

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,27 @@
       "dependencies": {
         "knex": "^3.1.0",
         "knex-ptosc-plugin": "^0.2.8",
-        "mysql2": "^3.9.4"
+        "mysql2": "^3.9.4",
+        "pino": "^10.0.0",
+        "prom-client": "^15.1.3"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/aws-ssl-profiles": {
@@ -22,6 +42,12 @@
       "engines": {
         "node": ">= 6.0.0"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/colorette": {
       "version": "2.0.19",
@@ -303,6 +329,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
@@ -314,6 +349,87 @@
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.2.tgz",
       "integrity": "sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA==",
       "license": "MIT"
+    },
+    "node_modules/pino": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.0.0.tgz",
+      "integrity": "sha512-eI9pKwWEix40kfvSzqEP6ldqOoBIN7dwD/o91TY5z8vQI12sAffpR/pOqAD1IVVwIVHDpHjkq0joBPdJD0rafA==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "slow-redact": "^0.3.0",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
+      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
+      "license": "MIT"
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
     },
     "node_modules/rechoir": {
       "version": "0.8.0",
@@ -356,6 +472,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -366,6 +491,30 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
       "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
+    },
+    "node_modules/slow-redact": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/slow-redact/-/slow-redact-0.3.1.tgz",
+      "integrity": "sha512-NvFvl1GuLZNW4U046Tfi8b26zXo8aBzgCAS2f7yVJR/fArN93mOqSA99cB9uITm92ajSz01bsu1K7SCVVjIMpQ==",
+      "license": "MIT"
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
+      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
     },
     "node_modules/sqlstring": {
       "version": "2.3.3",
@@ -395,6 +544,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
       }
     },
     "node_modules/tildify": {

--- a/package.json
+++ b/package.json
@@ -4,9 +4,14 @@
   "description": "Test app for knex-ptosc-plugin",
   "main": "index.js",
   "scripts": {
-    "migrate": "knex migrate:latest",
-    "rollback": "knex migrate:rollback",
-    "test": "node -e \"console.log('no tests')\""
+    "migrate": "node bin/ptosc-toolkit.js migrate",
+    "rollback": "node bin/ptosc-toolkit.js rollback",
+    "seed": "node bin/ptosc-toolkit.js seed",
+    "ptosc:plan": "node bin/ptosc-toolkit.js plan",
+    "ptosc:dry-run": "node bin/ptosc-toolkit.js dry-run",
+    "ptosc:validate": "node bin/ptosc-toolkit.js validate",
+    "db:wait": "node scripts/wait-for-mysql.js",
+    "test": "node --test tests"
   },
   "keywords": [],
   "author": "",
@@ -15,6 +20,8 @@
   "dependencies": {
     "knex": "^3.1.0",
     "knex-ptosc-plugin": "^0.2.8",
-    "mysql2": "^3.9.4"
+    "mysql2": "^3.9.4",
+    "pino": "^10.0.0",
+    "prom-client": "^15.1.3"
   }
 }

--- a/scripts/mock-ptosc.js
+++ b/scripts/mock-ptosc.js
@@ -13,11 +13,19 @@ function parseArgs(argv) {
     } else if (arg.startsWith('D=')) {
       const parts = arg.slice(2).split(',');
       for (const part of parts) {
-        const [key, value] = part.split('=');
-        if (key === 't') {
-          result.table = value;
-        } else if (key === '') {
+        const [rawKey, rawValue] = part.split('=');
+        const key = rawKey.trim();
+        const value = rawValue == null ? undefined : rawValue.trim();
+        if (!key && !value) {
           continue;
+        }
+        if (key === 't') {
+          result.table = value || '';
+        } else if (!key) {
+          // nothing else to infer
+          continue;
+        } else if (value == null || value === '') {
+          result.database = key;
         } else {
           result.database = value;
         }

--- a/scripts/mock-ptosc.js
+++ b/scripts/mock-ptosc.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+'use strict';
+
+const process = require('node:process');
+const mysql = require('mysql2/promise');
+
+function parseArgs(argv) {
+  const result = { raw: argv.slice(2) };
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--alter') {
+      result.alter = argv[++i];
+    } else if (arg.startsWith('D=')) {
+      const parts = arg.slice(2).split(',');
+      for (const part of parts) {
+        const [key, value] = part.split('=');
+        if (key === 't') {
+          result.table = value;
+        } else if (key === '') {
+          continue;
+        } else {
+          result.database = value;
+        }
+      }
+    } else if (arg.startsWith('--host=')) {
+      result.host = arg.slice(7);
+    } else if (arg.startsWith('--user=')) {
+      result.user = arg.slice(7);
+    } else if (arg === '--port') {
+      result.port = Number(argv[++i]);
+    } else if (arg === '--socket') {
+      result.socketPath = argv[++i];
+    } else if (arg === '--dry-run') {
+      result.dryRun = true;
+    } else if (arg === '--execute') {
+      result.execute = true;
+    }
+  }
+  return result;
+}
+
+async function applyAlter(config, alterClause) {
+  const connectionOptions = {
+    host: config.host || '127.0.0.1',
+    user: config.user,
+    database: config.database,
+    port: config.port,
+    socketPath: config.socketPath,
+    password: process.env.MYSQL_PWD
+  };
+  const connection = await mysql.createConnection(connectionOptions);
+  try {
+    const sql = `ALTER TABLE \`${config.table}\` ${alterClause}`;
+    await connection.query(sql);
+  } finally {
+    await connection.end();
+  }
+}
+
+async function main() {
+  const parsed = parseArgs(process.argv);
+  if (parsed.table) parsed.table = parsed.table.replace(/`/g, '');
+  if (parsed.database) parsed.database = parsed.database.replace(/`/g, '');
+  const alterClause = parsed.alter;
+  if (!alterClause) {
+    console.error('mock-ptosc: missing --alter clause');
+    process.exit(2);
+  }
+
+  const action = parsed.dryRun ? 'dry-run' : parsed.execute ? 'execute' : 'unknown';
+  const header = `[mock-ptosc] ${action} ${parsed.database}.${parsed.table}`;
+  console.log(header);
+  console.log('0% 00:00 remain');
+  console.error('50% 00:05 remain');
+  console.log('100% 00:00 remain');
+
+  if (parsed.execute && process.env.PTOSC_DRY_RUN_ONLY !== 'true') {
+    await applyAlter(parsed, alterClause);
+  }
+
+  console.log('# Event          Count');
+  console.log('# copy_rows      1000');
+  console.log('# chunk-size     1000');
+}
+
+main().catch((err) => {
+  console.error(err.stack || err.message);
+  process.exit(1);
+});

--- a/scripts/mock-ptosc.js
+++ b/scripts/mock-ptosc.js
@@ -50,7 +50,10 @@ async function applyAlter(config, alterClause) {
   };
   const connection = await mysql.createConnection(connectionOptions);
   try {
-    const sql = `ALTER TABLE \`${config.table}\` ${alterClause}`;
+    const trimmedAlter = (alterClause || '').trim();
+    const sql = /^alter\s+table/i.test(trimmedAlter)
+      ? trimmedAlter
+      : `ALTER TABLE \`${config.table}\` ${alterClause}`;
     await connection.query(sql);
   } finally {
     await connection.end();

--- a/scripts/wait-for-mysql.js
+++ b/scripts/wait-for-mysql.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+'use strict';
+
+const process = require('node:process');
+const mysql = require('mysql2/promise');
+
+const host = process.env.DB_HOST || '127.0.0.1';
+const user = process.env.DB_USER || 'root';
+const password = process.env.DB_PASSWORD || 'test';
+const port = Number(process.env.DB_PORT || 3306);
+const timeoutMs = Number(process.env.DB_WAIT_TIMEOUT_MS || 120000);
+const retryMs = Number(process.env.DB_WAIT_RETRY_MS || 2000);
+
+async function waitForMysql() {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    let connection;
+    try {
+      connection = await mysql.createConnection({ host, user, password, port });
+      await connection.ping();
+      await connection.end();
+      console.log('MySQL is ready.');
+      return process.exit(0);
+    } catch (err) {
+      if (connection) {
+        try { await connection.end(); } catch {}
+      }
+      console.log(`Waiting for MySQL at ${host}:${port} (${err.code || err.message})...`);
+      await new Promise((resolve) => setTimeout(resolve, retryMs));
+    }
+  }
+  console.error('MySQL did not become available before timeout.');
+  process.exit(1);
+}
+
+waitForMysql();

--- a/seeds/001_sample_data.js
+++ b/seeds/001_sample_data.js
@@ -1,0 +1,139 @@
+'use strict';
+
+const path = require('node:path');
+const fs = require('node:fs');
+
+function loadFixture(name) {
+  const filePath = path.join(__dirname, '..', 'fixtures', name);
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function createDeterministicRandom(seed = 1337) {
+  let value = seed % 2147483647;
+  if (value <= 0) value += 2147483646;
+  return () => {
+    value = (value * 16807) % 2147483647;
+    return (value - 1) / 2147483646;
+  };
+}
+
+exports.seed = async function (knex) {
+  const gadgetsFixture = loadFixture('gadgets.json');
+  const warehousesFixture = loadFixture('warehouses.json');
+  const customersFixture = loadFixture('customers.json');
+
+  const random = createDeterministicRandom();
+
+  await knex.transaction(async (trx) => {
+    await trx('inventory_snapshots').del();
+    await trx('order_items').del();
+    await trx('orders').del();
+    await trx('gadgets').del();
+    await trx('customers').del();
+    await trx('warehouses').del();
+
+    const warehouseIds = {};
+    for (const warehouse of warehousesFixture) {
+      const [id] = await trx('warehouses').insert({
+        code: warehouse.code,
+        region: warehouse.region
+      });
+      warehouseIds[warehouse.code] = id;
+    }
+
+    const gadgetIds = {};
+    for (const gadget of gadgetsFixture) {
+      const [id] = await trx('gadgets').insert({
+        title: gadget.title,
+        status: gadget.status,
+        qty: gadget.qty,
+        price: gadget.price,
+        warehouse_id: warehouseIds[gadget.warehouse] || null
+      });
+      gadgetIds[gadget.title] = id;
+    }
+
+    const customerIds = {};
+    for (const customer of customersFixture) {
+      const [id] = await trx('customers').insert({
+        external_id: customer.external_id,
+        email: customer.email,
+        full_name: customer.full_name,
+        status: customer.status
+      });
+      customerIds[customer.external_id] = id;
+    }
+
+    const ordersToInsert = [];
+    const orderItemsToInsert = [];
+    let orderCounter = 1;
+
+    const gadgetTitles = Object.keys(gadgetIds);
+
+    for (const customer of customersFixture) {
+      const orderCount = 20 + Math.floor(random() * 15);
+      for (let i = 0; i < orderCount; i++) {
+        const orderNumber = `ORD-${String(orderCounter).padStart(5, '0')}`;
+        const statusRoll = random();
+        const status = statusRoll > 0.85 ? 'cancelled' : statusRoll > 0.6 ? 'processing' : statusRoll > 0.2 ? 'fulfilled' : 'pending';
+        const totalItems = 1 + Math.floor(random() * 4);
+        const items = [];
+        let totalCents = 0;
+        for (let j = 0; j < totalItems; j++) {
+          const gadgetTitle = gadgetTitles[Math.floor(random() * gadgetTitles.length)];
+          const quantity = 1 + Math.floor(random() * 3);
+          const priceCents = Math.floor(random() * 90000) + 1000;
+          items.push({ gadgetTitle, quantity, priceCents });
+          totalCents += priceCents * quantity;
+        }
+        ordersToInsert.push({
+          order_number: orderNumber,
+          customer_id: customerIds[customer.external_id],
+          total_cents: totalCents,
+          status
+        });
+        orderItemsToInsert.push({ orderNumber, items });
+        orderCounter++;
+      }
+    }
+
+    const orderIds = [];
+    for (const order of ordersToInsert) {
+      const [id] = await trx('orders').insert(order);
+      orderIds.push(id);
+    }
+
+    for (let i = 0; i < orderItemsToInsert.length; i++) {
+      const { items } = orderItemsToInsert[i];
+      const orderId = orderIds[i];
+      for (const item of items) {
+        await trx('order_items').insert({
+          order_id: orderId,
+          gadget_id: gadgetIds[item.gadgetTitle],
+          quantity: item.quantity,
+          price_cents: item.priceCents
+        });
+      }
+    }
+
+    const snapshotDays = 30;
+    for (const gadgetTitle of gadgetTitles) {
+      const gadgetId = gadgetIds[gadgetTitle];
+      for (const warehouse of warehousesFixture) {
+        const warehouseId = warehouseIds[warehouse.code];
+        for (let dayOffset = 0; dayOffset < snapshotDays; dayOffset++) {
+          const quantity = Math.floor(200 + random() * 500);
+          const snapshotDate = new Date(Date.now() - dayOffset * 24 * 60 * 60 * 1000)
+            .toISOString()
+            .slice(0, 10);
+          await trx('inventory_snapshots').insert({
+            gadget_id: gadgetId,
+            warehouse_id: warehouseId,
+            snapshot_date: snapshotDate,
+            quantity
+          });
+        }
+      }
+    }
+  });
+};

--- a/src/ptosc-options.js
+++ b/src/ptosc-options.js
@@ -1,12 +1,18 @@
 'use strict';
 
 const http = require('node:http');
+const path = require('node:path');
+const fs = require('node:fs');
 const pino = require('pino');
 const client = require('prom-client');
 
 const DEFAULT_LOG_LEVEL = process.env.LOG_LEVEL || 'info';
 const METRICS_ENV = process.env.ENABLE_PTOSC_METRICS;
 const METRICS_ENABLED = METRICS_ENV == null || METRICS_ENV.toLowerCase() === 'true';
+const DEFAULT_PTOSC_BINARY = process.env.PTOSC_BINARY || 'pt-online-schema-change';
+const ALLOW_PTOSC_MOCK = process.env.PTOSC_ALLOW_MOCK !== 'false';
+
+let fallbackNoticeLogged = false;
 
 let baseLogger;
 let registry;
@@ -64,10 +70,81 @@ function normalizeLogger(migrationName, overrides) {
   };
 }
 
+function commandExists(candidate) {
+  if (!candidate) {
+    return false;
+  }
+  try {
+    fs.accessSync(candidate, fs.constants.X_OK);
+    return true;
+  } catch (err) {
+    // continue to PATH lookup below
+  }
+
+  if (candidate.includes(path.sep)) {
+    return false;
+  }
+
+  const pathEntries = process.env.PATH ? process.env.PATH.split(path.delimiter) : [];
+  const extensions = process.platform === 'win32'
+    ? (process.env.PATHEXT || '.EXE;.CMD;.BAT;.COM').split(';')
+    : [''];
+
+  for (const dir of pathEntries) {
+    for (const ext of extensions) {
+      const maybe = path.join(dir, `${candidate}${ext}`);
+      try {
+        fs.accessSync(maybe, fs.constants.X_OK);
+        return true;
+      } catch {
+        continue;
+      }
+    }
+  }
+  return false;
+}
+
+function resolvePtoscPath(ptoscPathOverride) {
+  if (ptoscPathOverride) {
+    return ptoscPathOverride;
+  }
+  if (process.env.PTOSC_PATH) {
+    return process.env.PTOSC_PATH;
+  }
+  if (commandExists(DEFAULT_PTOSC_BINARY)) {
+    return DEFAULT_PTOSC_BINARY;
+  }
+  if (ALLOW_PTOSC_MOCK) {
+    if (!fallbackNoticeLogged) {
+      getBaseLogger().warn(
+        { event: 'ptosc_mock_fallback', binary: DEFAULT_PTOSC_BINARY },
+        'pt-online-schema-change binary not found; falling back to mock implementation'
+      );
+      fallbackNoticeLogged = true;
+    }
+    return path.join(__dirname, '..', 'scripts', 'mock-ptosc.js');
+  }
+  if (!fallbackNoticeLogged) {
+    getBaseLogger().error(
+      { event: 'ptosc_binary_missing', binary: DEFAULT_PTOSC_BINARY },
+      'pt-online-schema-change binary not found and mock fallback disabled'
+    );
+    fallbackNoticeLogged = true;
+  }
+  return DEFAULT_PTOSC_BINARY;
+}
+
 function createPtoscOptions(migrationName, overrides = {}) {
-  const { logger: loggerOverride, onProgress: onProgressOverride, onStatistics: onStatisticsOverride, ...rest } = overrides;
+  const {
+    logger: loggerOverride,
+    onProgress: onProgressOverride,
+    onStatistics: onStatisticsOverride,
+    ptoscPath: ptoscPathOverride,
+    ...rest
+  } = overrides;
   const logger = normalizeLogger(migrationName, loggerOverride);
   const gauge = getProgressGauge();
+  const ptoscPath = resolvePtoscPath(ptoscPathOverride);
 
   const onProgress = (pct, eta) => {
     if (logger._pino) {
@@ -101,6 +178,10 @@ function createPtoscOptions(migrationName, overrides = {}) {
     onStatistics,
     ...rest
   };
+
+  if (ptoscPath) {
+    options.ptoscPath = ptoscPath;
+  }
 
   return options;
 }

--- a/src/ptosc-options.js
+++ b/src/ptosc-options.js
@@ -1,0 +1,152 @@
+'use strict';
+
+const http = require('node:http');
+const pino = require('pino');
+const client = require('prom-client');
+
+const DEFAULT_LOG_LEVEL = process.env.LOG_LEVEL || 'info';
+const METRICS_ENV = process.env.ENABLE_PTOSC_METRICS;
+const METRICS_ENABLED = METRICS_ENV == null || METRICS_ENV.toLowerCase() === 'true';
+
+let baseLogger;
+let registry;
+let progressGauge;
+let metricsServer;
+
+function getBaseLogger() {
+  if (!baseLogger) {
+    baseLogger = pino({
+      level: DEFAULT_LOG_LEVEL,
+      messageKey: 'message',
+      base: { service: 'kpp-test-app' }
+    });
+  }
+  return baseLogger;
+}
+
+function ensureRegistry() {
+  if (!registry) {
+    registry = new client.Registry();
+    client.collectDefaultMetrics({ register: registry });
+    progressGauge = new client.Gauge({
+      name: 'ptosc_progress_percent',
+      help: 'Progress percentage reported by pt-online-schema-change',
+      registers: [registry],
+      labelNames: ['migration']
+    });
+  }
+  return registry;
+}
+
+function getProgressGauge() {
+  if (!METRICS_ENABLED) {
+    return null;
+  }
+  if (!progressGauge) {
+    ensureRegistry();
+  }
+  return progressGauge;
+}
+
+function normalizeLogger(migrationName, overrides) {
+  if (overrides && overrides.log && overrides.error) {
+    return overrides;
+  }
+  const logger = getBaseLogger().child({ migration: migrationName });
+  return {
+    log(message) {
+      logger.info({ event: 'ptosc_log', message });
+    },
+    error(message) {
+      logger.error({ event: 'ptosc_error', message });
+    },
+    _pino: logger
+  };
+}
+
+function createPtoscOptions(migrationName, overrides = {}) {
+  const { logger: loggerOverride, onProgress: onProgressOverride, onStatistics: onStatisticsOverride, ...rest } = overrides;
+  const logger = normalizeLogger(migrationName, loggerOverride);
+  const gauge = getProgressGauge();
+
+  const onProgress = (pct, eta) => {
+    if (logger._pino) {
+      logger._pino.info({ event: 'ptosc_progress', pct, eta: eta || null }, 'pt-osc progress');
+    } else {
+      logger.log(`[PT-OSC] ${pct}%${eta ? ` ETA ${eta}` : ''}`);
+    }
+    if (gauge) {
+      gauge.set({ migration: migrationName }, pct);
+    }
+    if (typeof onProgressOverride === 'function') {
+      onProgressOverride(pct, eta);
+    }
+  };
+
+  const onStatistics = (stats) => {
+    if (logger._pino) {
+      logger._pino.info({ event: 'ptosc_statistics', stats });
+    } else {
+      logger.log(`[PT-OSC] stats: ${JSON.stringify(stats)}`);
+    }
+    if (typeof onStatisticsOverride === 'function') {
+      onStatisticsOverride(stats);
+    }
+  };
+
+  const options = {
+    logger,
+    onProgress,
+    statistics: true,
+    onStatistics,
+    ...rest
+  };
+
+  return options;
+}
+
+function startMetricsServer(port = Number(process.env.METRICS_PORT) || 9464) {
+  if (!METRICS_ENABLED) {
+    return null;
+  }
+  if (metricsServer) {
+    return metricsServer;
+  }
+  const register = ensureRegistry();
+  metricsServer = http.createServer(async (req, res) => {
+    if (req.url === '/metrics') {
+      try {
+        const metrics = await register.metrics();
+        res.statusCode = 200;
+        res.setHeader('Content-Type', register.contentType);
+        res.end(metrics);
+      } catch (err) {
+        res.statusCode = 500;
+        res.end(err.message);
+      }
+      return;
+    }
+    res.statusCode = 404;
+    res.end('Not Found');
+  });
+
+  metricsServer.listen(port, () => {
+    const address = metricsServer.address();
+    const boundPort = typeof address === 'object' && address ? address.port : port;
+    getBaseLogger().info({ event: 'metrics_server_started', port: boundPort }, 'pt-osc metrics server ready');
+  });
+  metricsServer.unref();
+
+  return metricsServer;
+}
+
+function getMetricsRegistry() {
+  return registry;
+}
+
+module.exports = {
+  createPtoscOptions,
+  startMetricsServer,
+  getMetricsRegistry,
+  getBaseLogger
+};

--- a/tests/ptosc-migrations.test.js
+++ b/tests/ptosc-migrations.test.js
@@ -91,7 +91,9 @@ test('migrations produce expected relational schema state', async (t) => {
   const fkConstraints = await knex('information_schema.referential_constraints')
     .select('constraint_name', 'table_name')
     .where({ constraint_schema: databaseName });
-  const orderFk = fkConstraints.find((row) => row.constraint_name.includes('orders_ibfk'));
+  const orderFk = fkConstraints.find(
+    (row) => typeof row.constraint_name === 'string' && row.constraint_name.includes('orders_ibfk')
+  );
   assert.ok(orderFk, 'expected orders table to retain foreign key to customers');
 
   const orderIndexes = await knex.raw('SHOW INDEX FROM orders');

--- a/tests/ptosc-migrations.test.js
+++ b/tests/ptosc-migrations.test.js
@@ -88,12 +88,16 @@ test('migrations produce expected relational schema state', async (t) => {
   const [{ total_snapshots }] = await knex('inventory_snapshots').count('* as total_snapshots');
   assert.ok(total_snapshots >= 450, 'expected at least 450 inventory snapshots');
 
-  const fkConstraints = await knex('information_schema.referential_constraints')
-    .select('constraint_name', 'table_name')
-    .where({ constraint_schema: databaseName });
-  const orderFk = fkConstraints.find(
-    (row) => typeof row.constraint_name === 'string' && row.constraint_name.includes('orders_ibfk')
-  );
+  const orderFk = await knex('information_schema.key_column_usage')
+    .select('constraint_name')
+    .where({
+      constraint_schema: databaseName,
+      table_name: 'orders',
+      column_name: 'customer_id',
+      referenced_table_name: 'customers',
+      referenced_column_name: 'id'
+    })
+    .first();
   assert.ok(orderFk, 'expected orders table to retain foreign key to customers');
 
   const orderIndexes = await knex.raw('SHOW INDEX FROM orders');

--- a/tests/ptosc-migrations.test.js
+++ b/tests/ptosc-migrations.test.js
@@ -1,0 +1,155 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const mysql = require('mysql2/promise');
+const knexFactory = require('knex');
+const { alterTableWithPtoscRaw } = require('knex-ptosc-plugin');
+const knexfile = require('../knexfile');
+const { createPtoscOptions, getMetricsRegistry, startMetricsServer } = require('../src/ptosc-options');
+
+const baseConfig = knexfile.development.connection;
+
+let adminConnection;
+let knex;
+let databaseName;
+let mysqlAvailable = true;
+let setupError;
+
+async function skipIfUnavailable(t) {
+  if (!mysqlAvailable) {
+    t.skip(`MySQL unavailable: ${setupError ? setupError.message : 'connection failed'}`);
+    return true;
+  }
+  return false;
+}
+
+test.before(async () => {
+  const adminConfig = {
+    host: baseConfig.host || '127.0.0.1',
+    user: baseConfig.user,
+    password: baseConfig.password,
+    port: baseConfig.port,
+    socketPath: baseConfig.socketPath
+  };
+
+  try {
+    adminConnection = await mysql.createConnection(adminConfig);
+    databaseName = `${baseConfig.database}_itest_${Date.now()}`;
+    await adminConnection.query(`CREATE DATABASE \`${databaseName}\``);
+
+    knex = knexFactory({
+      ...knexfile.development,
+      connection: {
+        ...knexfile.development.connection,
+        database: databaseName
+      }
+    });
+
+    await knex.migrate.latest();
+    await knex.seed.run();
+    startMetricsServer(0);
+  } catch (err) {
+    mysqlAvailable = false;
+    setupError = err;
+    if (knex) {
+      await knex.destroy();
+      knex = null;
+    }
+    if (adminConnection) {
+      try {
+        await adminConnection.end();
+      } catch {}
+      adminConnection = null;
+    }
+  }
+});
+
+test.after(async () => {
+  if (knex) {
+    await knex.destroy();
+  }
+  if (adminConnection && databaseName) {
+    try {
+      await adminConnection.query(`DROP DATABASE IF EXISTS \`${databaseName}\``);
+    } finally {
+      await adminConnection.end();
+    }
+  }
+});
+
+test('migrations produce expected relational schema state', async (t) => {
+  if (await skipIfUnavailable(t)) return;
+
+  const [{ total_orders }] = await knex('orders').count('* as total_orders');
+  assert.ok(total_orders > 75, 'expected seeded orders to exceed 75');
+
+  const [{ total_snapshots }] = await knex('inventory_snapshots').count('* as total_snapshots');
+  assert.ok(total_snapshots >= 450, 'expected at least 450 inventory snapshots');
+
+  const fkConstraints = await knex('information_schema.referential_constraints')
+    .select('constraint_name', 'table_name')
+    .where({ constraint_schema: databaseName });
+  const orderFk = fkConstraints.find((row) => row.constraint_name.includes('orders_ibfk'));
+  assert.ok(orderFk, 'expected orders table to retain foreign key to customers');
+
+  const orderIndexes = await knex.raw('SHOW INDEX FROM orders');
+  const indexRows = Array.isArray(orderIndexes[0]) ? orderIndexes[0] : orderIndexes;
+  const hasCompositeIndex = indexRows.some((idx) => idx.Key_name === 'orders_customer_placed_idx' && idx.Seq_in_index === 2);
+  assert.ok(hasCompositeIndex, 'expected composite index on orders(customer_id, placed_at)');
+
+  const gadgetsColumn = await knex('information_schema.columns')
+    .select('column_type')
+    .where({
+      table_schema: databaseName,
+      table_name: 'gadgets',
+      column_name: 'status'
+    })
+    .first();
+  assert.ok(gadgetsColumn.column_type.includes('enum'), 'expected gadgets.status to remain an enum');
+});
+
+test('pt-osc logs are captured via structured logger and metrics', async (t) => {
+  if (await skipIfUnavailable(t)) return;
+
+  const logLines = [];
+  const mockPtoscPath = path.join(__dirname, '..', 'scripts', 'mock-ptosc.js');
+
+  await alterTableWithPtoscRaw(
+    knex,
+    'ALTER TABLE gadgets MODIFY COLUMN title VARCHAR(255) NOT NULL',
+    createPtoscOptions('gadgets_adjust_title', {
+      logger: {
+        log: (msg) => logLines.push(msg),
+        error: (msg) => logLines.push(`ERR:${msg}`)
+      },
+      ptoscPath: mockPtoscPath,
+      forcePtosc: true
+    })
+  );
+
+  assert.ok(logLines.some((line) => line.includes('[PT-OSC] Running:')));
+  assert.ok(logLines.some((line) => line.includes('100%')));
+  assert.ok(logLines.some((line) => line.includes('Statistics')) || logLines.some((line) => line.includes('# chunk-size')));
+
+  const registry = getMetricsRegistry();
+  if (registry) {
+    const metric = registry.getSingleMetric && registry.getSingleMetric('ptosc_progress_percent');
+    if (metric) {
+      const values = metric.get().values || [];
+      const hasGaugeValue = values.some((value) => value.value === 100);
+      assert.ok(hasGaugeValue, 'expected progress gauge to reach 100');
+    }
+  }
+
+  const columnInfo = await knex('information_schema.columns')
+    .select('character_maximum_length')
+    .where({
+      table_schema: databaseName,
+      table_name: 'gadgets',
+      column_name: 'title'
+    })
+    .first();
+  assert.equal(columnInfo.character_maximum_length, 255);
+});


### PR DESCRIPTION
## Summary
- add a reusable ptosc toolkit CLI with structured logging/metrics helpers and deterministic mock pt-online-schema-change runner
- expand the sample schema, fixtures, and seeds to cover foreign keys, composite indexes, and larger datasets
- write integration tests and GitHub Actions coverage that exercise migrations with knex-ptosc-plugin and surface artifacts

## Testing
- npm test (skipped: MySQL unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e33f8ad2d883339fd1306e5c298cbf